### PR TITLE
replace sequelize.query() with certificate.create()

### DIFF
--- a/src/controllers/certificate.controller.ts
+++ b/src/controllers/certificate.controller.ts
@@ -1,11 +1,12 @@
-import sequelize from '../database/instance';
+import Certificate from '../database/models/certificate-model';
 import Student from '../database/models/student-model';
 
 async function postCertificate(student: Student, message: string) {
-  await sequelize.query(`
-        INSERT INTO certificates(student_id,agreement_id,message)
-        VALUES (${student.get().id}, ${student.get().agreement_id}, "${message}");
-    `);
+  await Certificate.create({
+    student_id: student.get().id,
+    agreement_id: student.get().agreement_id,
+    message,
+  }, { fields: ['student_id', 'agreement_id', 'message'] });
 }
 
 export default postCertificate;

--- a/src/database/instance.ts
+++ b/src/database/instance.ts
@@ -13,6 +13,7 @@ const sequelize = new Sequelize(database.name, database.username, database.passw
   host: database.host,
   dialect: database.dialect,
   logging: false, // Avoid default execution sequelize
+  timezone: '+02:00',
 });
 
 export default sequelize;


### PR DESCRIPTION
I had to use sequelize.query because sequelize.create didn't work. 

The create function was trying to insert the created_at and updated_at fields which are not supposed to be inserted by the ORM. 

I had to add `fields` array at the time of my create to specify which fields were to be inserted